### PR TITLE
Fix compile

### DIFF
--- a/cqueue.hpp
+++ b/cqueue.hpp
@@ -583,7 +583,7 @@ constexpr auto gto::cqueue<T, Allocator>::emplace_front(Args&&... args) -> refer
  * @exception std::out_of_range No elements to pop.
  */
 template<std::copyable T, typename Allocator>
-constexpr gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_front() {
+constexpr typename gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_front() {
   value_type ret{std::move(front())};
   allocator_traits::destroy(mAllocator, mData + mFront);
   mFront = getUncheckedIndex(1);
@@ -596,7 +596,7 @@ constexpr gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_f
  * @exception std::out_of_range No elements to pop.
  */
 template<std::copyable T, typename Allocator>
-constexpr gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_back() {
+constexpr typename gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_back() {
   value_type ret{std::move(back())};
   size_type index = getUncheckedIndex(mLength - 1);
   allocator_traits::destroy(mAllocator, mData + index);


### PR DESCRIPTION
Before:
```
➜  cqueue git:(main) make tests
c++ -g -std=c++20 -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnull-dereference -Weffc++ -o cqueue-tests cqueue-tests.cpp
In file included from cqueue-tests.cpp:6:
./cqueue.hpp:586:11: error: missing 'typename' prior to dependent type name 'gto::cqueue<T, Allocator>::value_type'
constexpr gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_front() {
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          typename 
./cqueue.hpp:599:11: error: missing 'typename' prior to dependent type name 'gto::cqueue<T, Allocator>::value_type'
constexpr gto::cqueue<T, Allocator>::value_type gto::cqueue<T, Allocator>::pop_back() {
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          typename 
2 errors generated.
make: *** [tests] Error 1
```
After:
```
➜  cqueue git:(main) ✗ make tests
c++ -g -std=c++20 -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnull-dereference -Weffc++ -o cqueue-tests cqueue-tests.cpp
./cqueue-tests
===============================================================================
All tests passed (592 assertions in 1 test case)
```
