### PR TITLE
Fix performace issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CXXFLAGS= -std=c++20 -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wn
 all: example tests coverage profiler
 
 profiler: cqueue-prof.cpp deque-prof.cpp
-	$(CXX) -std=c++20 -pg -g -o deque-prof deque-prof.cpp
-	$(CXX) -std=c++20 -pg -g -o cqueue-prof cqueue-prof.cpp
+	$(CXX) -std=c++20 -pg -g -O3 -o deque-prof deque-prof.cpp
+	$(CXX) -std=c++20 -pg -g -O3 -o cqueue-prof cqueue-prof.cpp
 	./cqueue-prof && gprof cqueue-prof gmon.out > cqueue-prof.gmon
 
 example: cqueue-example.cpp

--- a/cqueue-prof.cpp
+++ b/cqueue-prof.cpp
@@ -1,5 +1,8 @@
 #include "cqueue.hpp"
 
+#include <chrono>
+#include <iostream>
+
 #define INITIAL_SIZE 8
 #define NUM_ITERATIONS 1000000
 #define BATCH_SIZE 20
@@ -18,6 +21,7 @@ int main() {
     queue.push(i);
   }
 
+  auto t1 = std::chrono::steady_clock::now();
   for (int i = 0; i < NUM_ITERATIONS; i++) {
     for (int j = 0; j < BATCH_SIZE; j++) {
       queue.push(i);
@@ -26,4 +30,9 @@ int main() {
       queue.pop();
     }
   }
+  auto t2 = std::chrono::steady_clock::now();
+  std::cout
+      << "Elapsed time in microseconds : "
+      << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()
+      << " µs\n";
 }

--- a/cqueue.hpp
+++ b/cqueue.hpp
@@ -321,7 +321,7 @@ constexpr auto gto::cqueue<T, Allocator>::operator=(const cqueue &other) -> cque
  */
 template<std::copyable T, typename Allocator>
 constexpr auto gto::cqueue<T, Allocator>::getUncheckedIndex(size_type pos) const noexcept {
-  return ((mFront + pos) % (mReserved == 0 ? 1 : mReserved));
+  return (mFront + pos) & (mReserved - 1);
 }
 
 /**

--- a/deque-prof.cpp
+++ b/deque-prof.cpp
@@ -1,4 +1,6 @@
+#include <chrono>
 #include <deque>
+#include <iostream>
 
 #define INITIAL_SIZE 8
 #define NUM_ITERATIONS 1000000
@@ -18,6 +20,7 @@ int main() {
     queue.push_back(i);
   }
 
+  auto t1 = std::chrono::steady_clock::now();
   for (int i = 0; i < NUM_ITERATIONS; i++) {
     for (int j = 0; j < BATCH_SIZE; j++) {
       queue.push_back(i);
@@ -26,4 +29,9 @@ int main() {
       queue.pop_front();
     }
   }
+  auto t2 = std::chrono::steady_clock::now();
+  std::cout
+      << "Elapsed time in microseconds : "
+      << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()
+      << " µs\n";
 }


### PR DESCRIPTION
GCC default optimization level is 0, i.e. no optimization. Production environment usually has optimization level at least 2. 
When `-O3` is used, `cqueue` is three times slower than `std::deque`. The root cause is modulo operator. Every push/pop needs to modulo `reserved_`. 
Since `reserved_` is always power of 2. Modulo can be replaced by bit operation.
Before the PR
```
g++ -std=c++20 -g -03 -o deque-prof deque-prof.cpp
g++ -std=c++20 -g -03 -o cqueue-prof cqueue-prof.cpp
./deque-prof 
Elapsed time in microseconds : 63234 us
./cqueue-prof
Elapsed time in microseconds : 224606 us
```
After:
```
./deque-prof 
Elapsed time in microseconds : 63064 us
./cqueue-prof
Elapsed time in microseconds : 33249 us
```